### PR TITLE
Initialize stack variable to prevent an uninitialized read

### DIFF
--- a/checksum.c
+++ b/checksum.c
@@ -12,7 +12,7 @@ word16 checksum(byte *addr, word32 count);
 void main(void){
   byte        buff[BUFFER_LEN];
   word16      check;
-  word32      i;
+  word32      i = 0;
 
   FILE *archivo;
   FILE *escritura;


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).